### PR TITLE
Feat(user-data): adding new user controller

### DIFF
--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -58,15 +58,11 @@ const AuthController = new Elysia({ prefix: '/auth' })
       error({ code, error }) {
         switch (code) {
           case 'VALIDATION':
-            console.log(error.all);
-            
             const fields = [
               { path: '/email', field: 'email', message: 'Invalid email.' },
               { path: '/email', field: 'email', message: 'Email is required.' },
               { path: '/password', field: 'password', message: 'Password is required.' },
-              
-              // TODO: activate this later
-              // { path: '/password', field: 'password', message: 'Password must be at least 8 characters long.' }
+              { path: '/password', field: 'password', message: 'Password must be at least 8 characters long.' }
             ];
 
             const [errors] = fields
@@ -225,8 +221,8 @@ const AuthController = new Elysia({ prefix: '/auth' })
         switch (code) {
           case 'VALIDATION':
             const fields = [
-              { path: '/email', field: 'email', message: 'Invalid email.' },
               { path: '/email', field: 'email', message: 'Email is required.' },
+              { path: '/email', field: 'email', message: 'Invalid email.' },
               { path: '/password', field: 'password', message: 'Password is required.' },
               { path: '/password', field: 'password', message: 'Password must be at least 8 characters long.' },
               { path: '/phone', field: 'phone', message: 'Phone is required.' },

--- a/src/controllers/UserController.ts
+++ b/src/controllers/UserController.ts
@@ -1,0 +1,574 @@
+import { Elysia, t } from 'elysia';
+import { AuthMiddleware } from '../middlewares/AuthMiddleware';
+import { UserInfoRequest, UserSuccessResponse } from '../types/User';
+import { User, UserModel } from '../databases/model/User';
+import { GeneralResponse } from '../types/General';
+
+
+const UserController = new Elysia()
+    .group('/user', (app) => app
+      .use(AuthMiddleware)
+      .onBeforeHandle(async ({ authorized, set }) => {
+        if (!authorized) {
+          set.status = 401;
+          return {
+            status: 'error',
+            message: "Unauthorized."
+          }
+        }
+      })
+      .get("/get", async ({ user }) => {
+        const userData = user as User;
+        return {
+          status: 'success',
+          message: "Successfully retrieved user.",
+          data: {
+            id: userData.id,
+            fullName: userData.fullName,
+            phone: userData.phone,
+            email: userData.email
+          }
+        }
+      }, {
+        response: {
+          200: UserSuccessResponse,
+          401: GeneralResponse,
+        },
+        detail: {
+          summary: "Get User",
+          description: "Get an existing user.",
+          tags: ["Users"],
+          security: [{ JwtAuth: [] }],
+          responses: {
+            200: {
+              description: "Success",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      status: {
+                        type: "string",
+                        description: "Indicates if the request was success or error.",
+                        enum: ["success", "error"],
+                        example: "success"
+                      },
+                      message: {
+                        type: "string",
+                        description: "Message indicating the result of the request.",
+                        example: "Successfully retrieved user."
+                      },
+                      data: {
+                        description: "User data.",
+                        type: "object",
+                        properties: {
+                          id: {
+                            type: "number",
+                            description: "User ID.",
+                            example: 1
+                          },
+                          fullName: {
+                            type: "string",
+                            description: "User full name.",
+                            example: "John Doe"
+                          },
+                          phone: {
+                            type: "string",
+                            description: "User full name.",
+                            example: "John Doe"
+                          },
+                          email: {
+                            type: "string",
+                            description: "User email.",
+                            example: "john@example.com"
+                          },
+                        }
+                      }
+                    },
+                    required: ["status", "message", "data"]
+                  }
+                }
+              }
+            },
+            401: {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      status: {
+                        type: "string",
+                        description: "Indicates if the request was success or error.",
+                        enum: ["success", "error"],
+                        example: "error"
+                      },
+                      message: {
+                        type: "string",
+                        description: "Message indicating the result of the request.",
+                        example: "Forbidden."
+                      }
+                    },
+                    required: ["status", "message"]
+                  }
+                }
+              }
+            }
+          }
+        }
+      })
+      .put("/password", async ({ body, user, set }) => {
+        const { newPassword, oldPassword } = body;
+        const userData = user as User;
+        
+        const matchPassword = await Bun.password.verify(
+          oldPassword,
+          userData.password,
+          "bcrypt"
+        );
+        
+        if (!matchPassword) {
+          set.status = 401;
+          return {
+            status: 'error',
+            message: 'Invalid credentials'
+          };
+        }
+        
+        const hashedPassword = await Bun.password.hash(newPassword, "bcrypt");
+        const result = await UserModel.updatePassword(userData.id, hashedPassword);
+        if (result < 1) {
+          set.status = 422;
+          return {
+            status: 'error',
+            message: 'Error updating password'
+          };
+        }
+        
+        return {
+          status: 'success',
+          message: "Password changed successfully."
+        }
+      }, {
+        body: t.Object({
+          newPassword: t.String({ minLength: 8 }),
+          oldPassword: t.String({ minLength: 8 }),
+        }),
+        error({ code, error }) {
+          switch (code) {
+            case 'VALIDATION':
+              const fields = [
+                { path: '/oldPassword', field: 'newPassword', message: 'Old Password is required.' },
+                { path: '/oldPassword', field: 'newPassword', message: 'Old Password must be at least 8 characters long.' },
+                { path: '/newPassword', field: 'newPassword', message: 'New Password is required.' },
+                { path: '/newPassword', field: 'newPassword', message: 'New Password must be at least 8 characters long.' },
+              ];
+
+              const [errors] = fields
+                  .filter(field => error.all.some(e => e.summary && e.path === field.path))
+                  .map(field => ({ field: field.field, message: field.message }));
+
+              return {
+                status: 'error',
+                message: 'Invalid request.',
+                errors
+              }
+          }
+        },
+        response: {
+          200: GeneralResponse,
+          401: GeneralResponse,
+          422: GeneralResponse,
+        },
+        detail: {
+          summary: "Change Password",
+          description: "Change user password.",
+          tags: ["Users"],
+          security: [{ JwtAuth: [] }],
+          requestBody: {
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    newPassword: {
+                      type: "string",
+                      description: "User's password.",
+                      examples: "12345678"
+                    },
+                    oldPassword: {
+                      type: "string",
+                      description: "User's password.",
+                      examples: "12345678"
+                    }
+                  },
+                  required: ["newPassword", "oldPassword"]
+                }
+              }
+            }
+          },
+          responses: {
+            200: {
+              description: "Success",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      status: {
+                        type: "string",
+                        description: "Indicates if the request was success or error.",
+                        enum: ["success", "error"],
+                        example: "success"
+                      },
+                      message: {
+                        type: "string",
+                        description: "Message indicating the result of the request.",
+                        example: "Password changed successfully."
+                      }
+                    },
+                    required: ["status", "message"]
+                  }
+                }
+              }
+            },
+            401: {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      status: {
+                        type: "string",
+                        description: "Indicates if the request was success or error.",
+                        enum: ["success", "error"],
+                        example: "error"
+                      },
+                      message: {
+                        type: "string",
+                        description: "Message indicating the result of the request.",
+                        example: "Forbidden."
+                      }
+                    },
+                    required: ["status", "message"]
+                  }
+                }
+              }
+            },
+            422: {
+              description: "Unprocessable Entity",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      status: {
+                        type: "string",
+                        description: "Indicates if the request was success or error.",
+                        enum: ["success", "error"],
+                        example: "error"
+                      },
+                      message: {
+                        type: "string",
+                        description: "Message indicating the result of the request.",
+                        example: "Error updating password"
+                      }
+                    },
+                    required: ["status", "message"]
+                  }
+                }
+              }
+            }
+          }
+        }
+      })
+      .put("/email", async ({ body, userId, set }) => {
+        const { email } = body;    
+        const result = await UserModel.updateEmail(userId as number, email);
+        if (result < 1) {
+          set.status = 422;
+          return {
+            status: 'error',
+            message: 'Error updating email'
+          };
+        }
+        
+        return {
+          status: 'success',
+          message: "Email changed successfully."
+        }
+      }, {
+        body: t.Object({
+          email: t.String({ format: 'email' }),
+        }),
+        error({ code, error }) {
+          switch (code) {
+            case 'VALIDATION':
+              const fields = [
+                { path: '/email', field: 'email', message: 'Email is required.' },
+                { path: '/email', field: 'email', message: 'Invalid email.' },
+              ];
+
+              const [errors] = fields
+                  .filter(field => error.all.some(e => e.summary && e.path === field.path))
+                  .map(field => ({ field: field.field, message: field.message }));
+
+              return {
+                status: 'error',
+                message: 'Invalid request.',
+                errors
+              }
+          }
+        },
+        response: {
+          200: GeneralResponse,
+          401: GeneralResponse,
+          422: GeneralResponse,
+        },
+        detail: {
+          summary: "Change Email",
+          description: "Change user email.",
+          tags: ["Users"],
+          security: [{ JwtAuth: [] }],
+          requestBody: {
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    email: {
+                      type: "string",
+                      description: "User's email.",
+                      examples: "john@example.com"
+                    }
+                  },
+                  required: ["email"]
+                }
+              }
+            }
+          },
+          responses: {
+            200: {
+              description: "Success",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      status: {
+                        type: "string",
+                        description: "Indicates if the request was success or error.",
+                        enum: ["success", "error"],
+                        example: "success"
+                      },
+                      message: {
+                        type: "string",
+                        description: "Message indicating the result of the request.",
+                        example: "Email changed successfully."
+                      }
+                    },
+                    required: ["status", "message"]
+                  }
+                }
+              }
+            },
+            401: {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      status: {
+                        type: "string",
+                        description: "Indicates if the request was success or error.",
+                        enum: ["success", "error"],
+                        example: "error"
+                      },
+                      message: {
+                        type: "string",
+                        description: "Message indicating the result of the request.",
+                        example: "Forbidden."
+                      }
+                    },
+                    required: ["status", "message"]
+                  }
+                }
+              }
+            },
+            422: {
+              description: "Unprocessable Entity",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      status: {
+                        type: "string",
+                        description: "Indicates if the request was success or error.",
+                        enum: ["success", "error"],
+                        example: "error"
+                      },
+                      message: {
+                        type: "string",
+                        description: "Message indicating the result of the request.",
+                        example: "Error updating email"
+                      }
+                    },
+                    required: ["status", "message"]
+                  }
+                }
+              }
+            }
+          }
+        }
+      })
+      .put("/info", async ({ body, userId, set }) => {
+        const { phone, fullName } = body;
+        const result = await UserModel.updateNameAndPhone(userId as number, fullName, phone);
+        if (result < 1) {
+          set.status = 422;
+          return {
+            status: 'error',
+            message: 'Error updating info'
+          };
+        }
+        
+        return {
+          status: 'success',
+          message: "Info changed successfully."
+        }
+      }, {
+        body: UserInfoRequest,
+        error({ code, error }) {
+          switch (code) {
+            case 'VALIDATION':
+              const fields = [
+                { path: '/phone', field: 'phone', message: 'Phone is required.' },
+                { path: '/phone', field: 'phone', message: 'Phone max 20 characters long.' },
+                { path: '/fullName', field: 'fullName', message: 'Full Name is required.' },
+              ];
+
+              const [errors] = fields
+                  .filter(field => error.all.some(e => e.summary && e.path === field.path))
+                  .map(field => ({ field: field.field, message: field.message }));
+
+              return {
+                status: 'error',
+                message: 'Invalid request.',
+                errors
+              }
+          }
+        },
+        response: {
+          200: GeneralResponse,
+          401: GeneralResponse,
+          422: GeneralResponse,
+        },
+        detail: {
+          summary: "Change Info",
+          description: "Change user info.",
+          tags: ["Users"],
+          security: [{ JwtAuth: [] }],
+          requestBody: {
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    fullName: {
+                      type: "string",
+                      description: "User's full name.",
+                      examples: "John Doe"
+                    },
+                    phone: {
+                      type: "string",
+                      description: "User's phone.",
+                      examples: "081234132"
+                    }
+                  },
+                  required: ["fullName", "phone"]
+                }
+              }
+            }
+          },
+          responses: {
+            200: {
+              description: "Success",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      status: {
+                        type: "string",
+                        description: "Indicates if the request was success or error.",
+                        enum: ["success", "error"],
+                        example: "success"
+                      },
+                      message: {
+                        type: "string",
+                        description: "Message indicating the result of the request.",
+                        example: "Info changed successfully."
+                      }
+                    },
+                    required: ["status", "message"]
+                  }
+                }
+              }
+            },
+            401: {
+              description: "Unauthorized",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      status: {
+                        type: "string",
+                        description: "Indicates if the request was success or error.",
+                        enum: ["success", "error"],
+                        example: "error"
+                      },
+                      message: {
+                        type: "string",
+                        description: "Message indicating the result of the request.",
+                        example: "Forbidden."
+                      }
+                    },
+                    required: ["status", "message"]
+                  }
+                }
+              }
+            },
+            422: {
+              description: "Unprocessable Entity",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      status: {
+                        type: "string",
+                        description: "Indicates if the request was success or error.",
+                        enum: ["success", "error"],
+                        example: "error"
+                      },
+                      message: {
+                        type: "string",
+                        description: "Message indicating the result of the request.",
+                        example: "Error updating info"
+                      }
+                    },
+                    required: ["status", "message"]
+                  }
+                }
+              }
+            }
+          }
+        }
+      })
+    );
+    
+export default UserController;

--- a/src/databases/model/User.ts
+++ b/src/databases/model/User.ts
@@ -21,6 +21,16 @@ export class UserModel {
     const result = await db.update(users).set({ password: newPassword }).where(eq(users.id, id));
     return result.rowCount ?? 0;
   }
+  
+  static async updateEmail(id: number, email: string): Promise<number> {
+    const result = await db.update(users).set({ email }).where(eq(users.id, id));
+    return result.rowCount ?? 0;
+  }
+  
+  static async updateNameAndPhone(id: number, name: string, phone: string): Promise<number> {
+    const result = await db.update(users).set({ fullName: name, phone }).where(eq(users.id, id));
+    return result.rowCount ?? 0;
+  }
 
   static async getById(id: number): Promise<User | undefined> {
     const [user] = await db

--- a/src/databases/seed.ts
+++ b/src/databases/seed.ts
@@ -12,7 +12,7 @@ const main = async () => {
   
   console.log("Seed start");
   
-  const password = await Bun.password.hash("12345", {
+  const password = await Bun.password.hash("12345678", {
     algorithm: "bcrypt",
     cost: 10
   });
@@ -23,7 +23,7 @@ const main = async () => {
       email: faker.internet.email(),
       fullName: faker.person.fullName(),
       password,
-      phone: faker.phone.number(),
+      phone: faker.phone.number({ style: 'international'}),
     });
     
     if (i === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import swagger from '@elysiajs/swagger';
 import { Elysia } from "elysia";
 import { EnvManager } from './utils/EnvManager';
 import AuthController from './controllers/AuthController';
+import UserController from './controllers/UserController';
 
 const port: number = EnvManager.getPort();
 const app = new Elysia()
@@ -40,6 +41,7 @@ const app = new Elysia()
   .group('/api', (app) => 
     app
       .use(AuthController)
+      .use(UserController)
   )
   .listen(port);
 

--- a/src/middlewares/AuthMiddleware.ts
+++ b/src/middlewares/AuthMiddleware.ts
@@ -29,7 +29,7 @@ export const AuthMiddleware = (app: Elysia) => {
 
         // TODO: secure this logic with encryption or else
         const id = jwtPayload.id;
-        const user = UserModel.getById(id as number);
+        const user = await UserModel.getById(id as number);
 
         if (!user) {
           set.status = 401;
@@ -39,7 +39,9 @@ export const AuthMiddleware = (app: Elysia) => {
         }
 
         return {
-          authorized: true
+          authorized: true,
+          user,
+          userId: id
         }
     });
 };

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -6,7 +6,6 @@ export const LoginBodyRequest = t.Object({
     format: 'email',
   }),
   password: t.String({
-    format: 'password',
     minLength: 8
   }),
 });

--- a/src/types/General.ts
+++ b/src/types/General.ts
@@ -4,3 +4,9 @@ export const GeneralResponse = t.Object({
   status: t.String(),
   message: t.String(),
 });
+
+export const ParamId = t.Object({
+  id: t.String({
+    required: true,
+  })
+});

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -1,0 +1,22 @@
+import { t } from 'elysia';
+import { GeneralResponse } from './General';
+
+
+const UserDataObject = t.Object({
+  id: t.Number(),
+  fullName: t.String(),
+  email: t.String(),
+  phone: t.String()
+});
+
+export const UserSuccessResponse = t.Object({
+  ...GeneralResponse.properties,
+  data: UserDataObject
+});
+
+export const UserInfoRequest = t.Object({
+  fullName: t.String(),
+  phone: t.String({
+    maxLength: 20
+  })
+})


### PR DESCRIPTION
### Add new API
adding user controller API for:
- get user data
- update email only
- update password only with checking on old password
- update user info (in this case are full name and phone) 

### Changes
- fix some bugs on AuthMiddleware
- passing user on middleware for query efficiency, can call directly on controller
- passing userId for updating user data, userId is from jwt-token in header

### Notes
user endpoint cannot pass id on the url (e.g: user/:id) this is bad, 
userId will take from jwt-token instead for security leak purpose.